### PR TITLE
Fix broken image export

### DIFF
--- a/www/sketch.js
+++ b/www/sketch.js
@@ -365,39 +365,37 @@
 
   // Exports the current sketch as a PNG by opening a new popup window.
   // The popup contains an instruction, the full-resolution image, and a save link.
-  // The blob URL is revoked after 60 seconds to free memory.
+  // Uses a data URL (self-contained base64) rather than a blob URL to avoid
+  // cross-context blob access failures in restrictive browser security environments
+  // (e.g. enterprise policies blocking blob URL access from iframe-opened popups).
   function openInNewWindow() {
     var flat     = buildFlat();
     var filename = slugify(getCaption()) + '.png';
-    flat.toBlob(function(blob) {
-      var blobUrl = URL.createObjectURL(blob);
-      var win = window.open('', '_blank');
-      if (!win) {
-        setStatus('Popup blocked - please allow popups and try again');
-        URL.revokeObjectURL(blobUrl);
-        return;
-      }
-      var d = win.document;
-      d.title = filename;
-      d.body.style.cssText = 'margin:0;background:#f0f0f0;display:flex;flex-direction:column;align-items:center;padding:24px;gap:16px;font-family:monospace;color:#333;height:100vh;box-sizing:border-box;overflow:hidden;';
-      var p = d.createElement('p');
-      p.style.cssText = 'font-family:monospace;font-size:0.9rem;color:#666;text-transform:uppercase;letter-spacing:1px;';
-      p.textContent = 'Right-click the image to copy, or save using the button below.';
-      d.body.appendChild(p);
-      var img = d.createElement('img');
-      img.src = blobUrl;
-      img.style.cssText = 'flex:1;min-height:0;max-width:100%;object-fit:contain;border:1px solid #ccc;border-radius:6px;box-shadow:0 2px 12px rgba(0,0,0,0.1);';
-      d.body.appendChild(img);
-      var a = d.createElement('a');
-      a.href = blobUrl;
-      a.download = filename;
-      a.style.cssText = 'display:inline-flex;align-items:center;height:52px;padding:0 40px;background:#222;color:#fff;font-family:monospace;font-size:1rem;text-transform:uppercase;letter-spacing:1px;text-decoration:none;border-radius:6px;border:1px solid #222;';
-      a.textContent = '\u2193 Save as ' + filename;
-      d.body.appendChild(a);
-      setTimeout(function() { URL.revokeObjectURL(blobUrl); }, 60000);
-      setStatus('\u2197 Opened in new window');
-      setTimeout(function() { setStatus(''); }, 5000);
-    }, 'image/png');
+    var dataUrl  = flat.toDataURL('image/png');
+    var win = window.open('', '_blank');
+    if (!win) {
+      setStatus('Popup blocked - please allow popups and try again');
+      return;
+    }
+    var d = win.document;
+    d.title = filename;
+    d.body.style.cssText = 'margin:0;background:#f0f0f0;display:flex;flex-direction:column;align-items:center;padding:24px;gap:16px;font-family:monospace;color:#333;height:100vh;box-sizing:border-box;overflow:hidden;';
+    var p = d.createElement('p');
+    p.style.cssText = 'font-family:monospace;font-size:0.9rem;color:#666;text-transform:uppercase;letter-spacing:1px;';
+    p.textContent = 'Right-click the image to copy, or save using the button below.';
+    d.body.appendChild(p);
+    var img = d.createElement('img');
+    img.src = dataUrl;
+    img.style.cssText = 'flex:1;min-height:0;max-width:100%;object-fit:contain;border:1px solid #ccc;border-radius:6px;box-shadow:0 2px 12px rgba(0,0,0,0.1);';
+    d.body.appendChild(img);
+    var a = d.createElement('a');
+    a.href = dataUrl;
+    a.download = filename;
+    a.style.cssText = 'display:inline-flex;align-items:center;height:52px;padding:0 40px;background:#222;color:#fff;font-family:monospace;font-size:1rem;text-transform:uppercase;letter-spacing:1px;text-decoration:none;border-radius:6px;border:1px solid #222;';
+    a.textContent = '\u2193 Save as ' + filename;
+    d.body.appendChild(a);
+    setStatus('\u2197 Opened in new window');
+    setTimeout(function() { setStatus(''); }, 5000);
   }
 
   // Expose only what the HTML onclick attributes need


### PR DESCRIPTION
closes #8 

The root cause is likely a blob URL cross-context access issue, exacerbated by enterprise browser security policies on the work laptop.

  What's happening:

  1. URL.createObjectURL(blob) creates a blob:https://your-app.com/uuid URL — this blob is owned by the iframe's browsing context
  2. window.open('', '_blank') opens a new popup that starts as about:blank — it has a different browsing context
  3. When the popup tries to load img.src = blobUrl, the browser has to access a blob owned by the iframe's context from the popup's context
  4. On your personal laptop this works (browsers are lenient); on the work laptop, enterprise Chrome/Edge policies likely enforce stricter cross-context blob URL access, hence ERR_FILE_NOT_FOUND

  The "right-click → open image in new tab" works because that action navigates the current context (which owns the blob) rather than loading it
   from a foreign context.

  The fix: Replace toBlob + createObjectURL with toDataURL(). A data URL is self-contained base64 — no cross-context ownership issues at all.